### PR TITLE
Enabling special kernel as for example the linux mainline one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 Patch/Compile/Install bluetooth driver for:
 
+############## MY PERSONAL REMARKS ########################
+
+I customized the installation script in order to support any linux kernel, for example the 'linux-mainline' as well as the 'linux-libre' with the possibility for the user to provide the website link to download the tar file of his custom linux kernel. For further information, check the comments of my customized script which explains in details the changes and enhancement.
+
+To use it, only need to run the custom script with sudo from this repo.
+
+For the moment, it works (successfully tested) with :
+- Arch Linux
+
+############## REMARKS FROM THE OFFICIAL DIR ##############
+
 Macbook Pro models: 13,1 and 14,1
 Macbook 12 inch models (2015 and later): 8,1 + 9,1 + 10,1
 

--- a/install.bluetooth.sh
+++ b/install.bluetooth.sh
@@ -37,20 +37,49 @@ bluetooth_dir="$build_dir/bluetooth"
 [[ ! -d $build_dir ]] && mkdir $build_dir
 
 # attempt to download linux-x.x.x.tar.xz kernel
-wget -c https://cdn.kernel.org/pub/linux/kernel/v$major_version.x/linux-$kernel_version.tar.xz -P $build_dir
+KERNEL_DOWNLOAD_TAR_URL="https://cdn.kernel.org/pub/linux/kernel/v$major_version.x/linux-$kernel_version.tar.xz"
+wget -c "$KERNEL_DOWNLOAD_TAR_URL" -P $build_dir
 
 if [[ $? -ne 0 ]]; then
    # if first attempt fails, attempt to download linux-x.x.tar.xz kernel
    kernel_version=$kernel_short_version
-   wget -c https://cdn.kernel.org/pub/linux/kernel/v$major_version.x/linux-$kernel_version.tar.xz -P $build_dir
+   KERNEL_DOWNLOAD_TAR_URL="https://cdn.kernel.org/pub/linux/kernel/v$major_version.x/linux-$kernel_version.tar.xz"
+   wget -c "$KERNEL_DOWNLOAD_TAR_URL" -P $build_dir
 fi
 
-[[ $? -ne 0 ]] && echo "kernel could not be downloaded...exiting" && exit
+#######################
+[[ $? -ne 0 ]] && echo "kernel could not be downloaded... Retry by manually writing the url of the kernel tar file." &&
+# Block to get the url from the user
+{ read -p "IMPORTANT:
+
+So far, the download of the tar file failed... But : 
+
+If you are using a custom kernel (as for example the 'mainline'),
+please carefully copy/paste the link to the tarball (format tar.xz or tar.gz) file here and then type 'enter'.
+
+Be cautious, this is custom script adaptation without further checks...
+" KERNEL_DOWNLOAD_TAR_URL
+} && wget -c "$KERNEL_DOWNLOAD_TAR_URL" -P $build_dir &&
+# Customization for special kernel
+# 2 customizations :
+#    get the extension of tar file (+'tar.') : so tar.xz or tar.gz
+#    get the kernel version is special kernel
+{ END_OF_TAR_FILE="${KERNEL_DOWNLOAD_TAR_URL%/}" # remove eventual ending slash
+  BEGINNING_OF_URL_WITHOUT_END="${END_OF_TAR_FILE%tar.*}"
+  END_OF_TAR_FILE="${END_OF_TAR_FILE##$BEGINNING_OF_URL_WITHOUT_END}"
+  kernel_version="${BEGINNING_OF_URL_WITHOUT_END##*/}"
+  kernel_version="${kernel_version##linux-}" # removing the 'linux-'
+  kernel_version="${kernel_version%.}" # removing any eventual ending dot
+}
+
+# Test is wget returned an error and exit if so
+[[ $? -ne 0 ]] && echo "the custom kernel could not be downloaded...exiting" && exit
 
 # remove old kernel tar.xz archives
-find build/ -type f | grep -E linux.*.tar.xz | grep -v $kernel_version.tar.xz | xargs rm -f
+find build/ -type f | grep -E linux.*.${END_OF_TAR_FILE} | grep -v $kernel_version.${END_OF_TAR_FILE} | xargs rm -f
 
-tar --strip-components=2 -xvf $build_dir/linux-$kernel_version.tar.xz --directory=build/ linux-$kernel_version/drivers/bluetooth
+tar --strip-components=2 -xvf $build_dir/linux-$kernel_version.${END_OF_TAR_FILE} --directory=build/ linux-$kernel_version/drivers/bluetooth
+
 mv $bluetooth_dir/Makefile $bluetooth_dir/Makefile.orig
 cp -p $bluetooth_dir/hci_bcm.c $bluetooth_dir/hci_bcm.c.orig
 cp $patch_dir/Makefile $bluetooth_dir/


### PR DESCRIPTION
Added a third case for special kernels (as for example the 'linux mainline one)

If the two first 'wget' attemps fail, the user has the possibility (and the responsability) to provide a custom 'linux.*.tar.*' url in order to download special kernel not listed in the '' repository (as https://git.kernel.org/torvalds/t/linux-6.7-rc7.tar.gz).

Tested with both kernel 6.6.8 and 6.7-rc6 andbluetooth is available.

Two modifications were made : stock the 'wget' download url into a variable and get the end of the tar file (which enable to use both 'tar.xz' as well as 'tar.gz' kernel files). It is important to enable at least the linux mainline kernel for macbook pro users.